### PR TITLE
add basic chart for total successful checks overtime

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ ruby '2.1.1'
 gem 'twilio-ruby'
 gem 'sinatra'
 gem 'rack-ssl'
+gem 'plotly'
 
 group :development do
   gem 'pry'

--- a/balance_metrics.rb
+++ b/balance_metrics.rb
@@ -4,6 +4,8 @@ require 'time'
 require 'rack/ssl'
 require 'date'
 require 'time'
+require 'plotly'
+require 'pry'
 
 if settings.environment != :development
   use Rack::SSL unless settings.environment == :development
@@ -13,6 +15,7 @@ if settings.environment != :development
 end
 
 get '/' do
+  # Get raw stats
   client = Twilio::REST::Client.new(ENV['TWILIO_BALANCE_PROD_SID'], ENV['TWILIO_BALANCE_PROD_AUTH'])
   @phone_number_hash = Hash.new
   client.account.incoming_phone_numbers.list.each do |number|
@@ -26,10 +29,50 @@ get '/' do
   @inbound_messages = all_messages.select { |m| m.direction == 'inbound' }
   all_calls = process_multipage_list(client.account.calls.list, Array.new)
   @inbound_calls = all_calls.select { |m| m.direction == 'inbound' }
+
+  # Make some chartz
+  plotly = PlotLy.new(ENV['PLOTLY_USERNAME'], ENV['PLOTLY_API_KEY'])
+
+  # Get data
+  @check_dates = []
+  @successful_outbound_balance_texts.each do |sms|
+    @check_dates << Date.parse(sms.date_sent).to_date
+  end
+
+  @check_hash = Hash[@check_dates.group_by {|x| x}.map {|k,v| [k,v.count]}]
+  y = @check_hash.values.reverse
+  sum = 0
+  @y_cumulative = y.map { |i| sum += i }
+  data = {
+    'x' => @check_hash.keys.map { |d| d.strftime }.reverse,
+    'y' => @y_cumulative
+  }
+
+  kwargs = {
+    filename: 'Balance metrics',
+    # fileopt: 'overwrite',
+    style: { type: 'scatter' },
+    layout: {
+      title: 'Total successful checks'
+    },
+    world_readable: true
+  }
+
+  @chart_url = ""
+  plotly.plot(data, kwargs) do |response|
+    @chart_url = response['url']
+  end
+
+  # Render index
   erb :index
 end
 
 helpers do
+  # def cumulative_sum(array)
+  #   sum = 0
+  #   array.map{|x| sum += x}
+  # end
+
   def process_multipage_list(list, return_array)
     list.each do |item|
       return_array << item

--- a/views/index.erb
+++ b/views/index.erb
@@ -1,5 +1,8 @@
 <h1>Balance Metrics</h1>
 
+<h2>Metrics</h2>
+<iframe width='800' height='600' frameborder='0' seamless='seamless' scrolling='no' src='<%= @chart_url %>.embed?width=800&height=600'></iframe>
+
 <h2>Successful Balance Checks: <%= @successful_outbound_balance_texts.count %></h2>
   <% @successful_outbound_balance_texts.each do |m| %>
     <li>
@@ -25,4 +28,3 @@
     </li>
   <% end %>
 </ul>
-


### PR DESCRIPTION
This pull adds a basic '# success checks' time series, like this:
![screen shot 2014-08-20 at 2 02 25 pm](https://cloud.githubusercontent.com/assets/2533112/3988199/af0b6326-28ad-11e4-9ace-aea5ad1a79d6.png)

I'm generating these charts with plot.ly, so you'll need to add two more environment variables (I'll DM you my credentials for now):
- PLOTLY_USERNAME
- PLOTLY_API_KEY

In the future we should separate out the public component so these charts can be embedded in the readme.
